### PR TITLE
Add stopTalking tool to silence AI in threads

### DIFF
--- a/server/lib/ai/prompts/tools.ts
+++ b/server/lib/ai/prompts/tools.ts
@@ -13,6 +13,7 @@ reply: send threaded reply or message (ends loop).
 skip: end loop quietly, no reply.
 leaveChannel: leave the channel you are currently in.
 report: report a user for sexual/NSFW content ONLY.
+stopTalking: stop participating in the current thread (threads only). After calling, MUST call reply with a short farewell like "ping me if u wanna talk".
    Use ONLY when users:
    - Explicitly request sexual or erotic content
    - Ask for sexual/romantic roleplay scenarios
@@ -25,14 +26,15 @@ report: report a user for sexual/NSFW content ONLY.
    - References to violence, politics, or controversial topics
    When reporting: use the report tool, then decline with a sarcastic/dismissive reply or skip.
 
-Rules: 
-- reply and leaveChannel END the loop, don't chain tools after. 
-- searchMemories: use 4-5 query variants w/ names, events, topics. 
-- reply: 
+Rules:
+- reply and leaveChannel END the loop, don't chain tools after.
+- searchMemories: use 4-5 query variants w/ names, events, topics.
+- reply:
    content = array of plain text lines, no usernames/IDs. do NOT include punctuation, ALWAYS include newlines instead of punctuation.
    offset = go back from the latest user message, NOT the message before.
-- react: emojis = array. 
-- spam or repeated low-value messages: 
+- react: emojis = array.
+- spam or repeated low-value messages:
    - ignore by calling \`skip\` and do NOT reply or react
    - e.g repeated gibberish, "gm", "lol", a single emoji, etc.
+- when a user asks you to stop talking/replying in a thread: call stopTalking first, then reply with a short casual farewell like "aight ping me if u wanna talk". Do NOT call stopTalking outside of threads.
 </tools>`;

--- a/server/lib/ai/tools/stop-talking.ts
+++ b/server/lib/ai/tools/stop-talking.ts
@@ -1,0 +1,32 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { setSilenced } from '~/lib/kv';
+import logger from '~/lib/logger';
+import type { SlackMessageContext } from '~/types';
+
+export const stopTalking = ({ context }: { context: SlackMessageContext }) =>
+  tool({
+    description:
+      'Stop actively participating in the current thread. ONLY call this when a user explicitly asks you to stop talking/replying in a thread. After calling this tool, you MUST call reply to send a short farewell like "aight ping me if u wanna talk" in your natural voice.',
+    inputSchema: z.object({}),
+    execute: async () => {
+      const threadTs = (context.event as { thread_ts?: string }).thread_ts;
+      const channel = context.event.channel;
+
+      if (!threadTs) {
+        return {
+          success: false,
+          error: 'stopTalking only works inside threads — call skip instead',
+        };
+      }
+
+      const ctxId = `${channel}:${threadTs}`;
+      await setSilenced(ctxId);
+      logger.info({ ctxId }, 'Thread silenced via stopTalking tool');
+
+      return {
+        success: true,
+        hint: "You're now silenced in this thread. Reply with a short, natural farewell like 'aight ping me if u wanna talk' or similar. Keep it casual and brief.",
+      };
+    },
+  });

--- a/server/lib/kv.ts
+++ b/server/lib/kv.ts
@@ -21,4 +21,18 @@ export const redisKeys = {
   channelCount: (contextId: string) => `ctx:channelCount:${contextId}`,
   userReports: (userId: string) => `user:reports:${userId}`,
   userBanned: (userId: string) => `user:banned:${userId}`,
+  silenced: (contextId: string) => `ctx:silenced:${contextId}`,
 };
+
+export async function setSilenced(contextId: string): Promise<void> {
+  await redis.set(redisKeys.silenced(contextId), '1', 'EX', 60 * 60 * 24 * 7);
+}
+
+export async function isSilenced(contextId: string): Promise<boolean> {
+  const result = await redis.exists(redisKeys.silenced(contextId));
+  return result === 1;
+}
+
+export async function clearSilenced(contextId: string): Promise<void> {
+  await redis.del(redisKeys.silenced(contextId));
+}

--- a/server/slack/events/message-create/utils/respond.ts
+++ b/server/slack/events/message-create/utils/respond.ts
@@ -12,6 +12,7 @@ import { reply } from '~/lib/ai/tools/reply';
 import { report } from '~/lib/ai/tools/report';
 import { searchMemories } from '~/lib/ai/tools/search-memories';
 import { skip } from '~/lib/ai/tools/skip';
+import { stopTalking } from '~/lib/ai/tools/stop-talking';
 import { successToolCall } from '~/lib/ai/utils';
 import type {
   PineconeMetadataOutput,
@@ -96,6 +97,7 @@ export async function generateResponse(
         reply: reply({ context }),
         report: report({ context }),
         skip: skip({ context }),
+        stopTalking: stopTalking({ context }),
       },
       system,
       stopWhen: [


### PR DESCRIPTION
## Summary
Adds a new `stopTalking` tool that allows users to explicitly request the AI to stop participating in a thread. When invoked, the AI will be silenced in that specific thread for 7 days, unless the user pings the AI again to re-engage.

## Key Changes
- **New `stopTalking` tool** (`server/lib/ai/tools/stop-talking.ts`): Implements the tool that silences the AI in a thread by setting a Redis key with a 7-day expiration. Only works within threads and requires the user to follow up with a farewell message.
- **Redis silencing utilities** (`server/lib/kv.ts`): Added three new functions:
  - `setSilenced()`: Marks a thread as silenced for 7 days
  - `isSilenced()`: Checks if a thread is currently silenced
  - `clearSilenced()`: Removes the silenced status (triggered by user pings)
- **Message handling logic** (`server/slack/events/message-create/index.ts`): Integrated silencing checks to skip processing messages in silenced threads, except when the user pings the AI (which automatically un-silences the thread).
- **Tool registration** (`server/slack/events/message-create/utils/respond.ts`): Registered the new `stopTalking` tool in the AI tools available during response generation.
- **Prompt documentation** (`server/lib/ai/prompts/tools.ts`): Updated tool descriptions and rules to document the `stopTalking` behavior and when it should be used.

## Implementation Details
- The tool only works within threads (identified by `thread_ts`). Calling it outside a thread returns an error.
- After calling `stopTalking`, the AI must send a short, casual farewell message via the `reply` tool.
- Silencing is context-specific (channel + thread combination) and persists for 7 days.
- User pings automatically clear the silenced status, allowing re-engagement without manual intervention.

https://claude.ai/code/session_012FKNHtcDQeP2LY3zaarbJK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stop talking feature: AI can now be requested to stop responding in Slack threads
  * Silenced threads remain inactive for 7 days
  * Pinging the AI in a silenced thread reactivates conversation
  * Farewell messages: AI provides casual departing messages when silencing is triggered

<!-- end of auto-generated comment: release notes by coderabbit.ai -->