### PR TITLE
add /gork stop subcommand to silence gork in threads/channels

### DIFF
--- a/.cspell.jsonc
+++ b/.cspell.jsonc
@@ -37,6 +37,7 @@
     "xapp",
     "xoxb",
     "aight",
+    "cooldown",
     "exalabs",
     "unban",
     "Unban",

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,6 +5,11 @@ description: |
 runs:
   using: composite
   steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
     - name: Setup bun
       uses: oven-sh/setup-bun@v2
 

--- a/server/slack/commands/index.ts
+++ b/server/slack/commands/index.ts
@@ -1,4 +1,5 @@
 import { execute as banExecute, name as banName } from './ban';
+import { execute as leaveExecute, name as leaveName } from './leave';
 import { execute as reportsExecute, name as reportsName } from './reports';
 import { execute as stopExecute, name as stopName } from './stop';
 import { execute as unbanExecute, name as unbanName } from './unban';
@@ -8,6 +9,7 @@ const subcommands = [
   { name: unbanName, execute: unbanExecute },
   { name: reportsName, execute: reportsExecute },
   { name: stopName, execute: stopExecute },
+  { name: leaveName, execute: leaveExecute },
 ] as const;
 
 const WHITESPACE_PATTERN = /\s+/;

--- a/server/slack/commands/index.ts
+++ b/server/slack/commands/index.ts
@@ -1,11 +1,13 @@
 import { execute as banExecute, name as banName } from './ban';
 import { execute as reportsExecute, name as reportsName } from './reports';
+import { execute as stopExecute, name as stopName } from './stop';
 import { execute as unbanExecute, name as unbanName } from './unban';
 
 const subcommands = [
   { name: banName, execute: banExecute },
   { name: unbanName, execute: unbanExecute },
   { name: reportsName, execute: reportsExecute },
+  { name: stopName, execute: stopExecute },
 ] as const;
 
 const WHITESPACE_PATTERN = /\s+/;

--- a/server/slack/commands/leave.ts
+++ b/server/slack/commands/leave.ts
@@ -1,0 +1,67 @@
+import type {
+  AllMiddlewareArgs,
+  SlackCommandMiddlewareArgs,
+} from '@slack/bolt';
+import { leaveChannelBlocklist } from '~/config';
+import { env } from '~/env';
+import logger from '~/lib/logger';
+
+export const name = 'leave';
+
+const SLACK_USER_ID_REGEX = /^[UW][A-Z0-9]+$/;
+
+export async function execute(
+  context: SlackCommandMiddlewareArgs & AllMiddlewareArgs
+) {
+  const { ack, body, client, respond } = context;
+
+  await ack();
+
+  const channelId = body.channel_id;
+  const userId = body.user_id;
+
+  const blocked = leaveChannelBlocklist.find((c) => c.id === channelId);
+  if (blocked) {
+    await respond({
+      text: `cannot leave #${blocked.name} — this channel is protected.`,
+      response_type: 'ephemeral',
+    });
+    return;
+  }
+
+  const safeUserId =
+    userId && SLACK_USER_ID_REGEX.test(userId) ? userId : undefined;
+
+  if (env.LOGS_CHANNEL) {
+    try {
+      await client.chat.postMessage({
+        channel: env.LOGS_CHANNEL,
+        text: safeUserId
+          ? `<@${safeUserId}> asked the bot to leave <#${channelId}> via /gork leave`
+          : `The bot was asked to leave <#${channelId}> via /gork leave`,
+      });
+    } catch (error) {
+      logger.error({ error, channelId, userId }, 'Failed to send leave-channel log');
+    }
+  }
+
+  try {
+    await client.chat.postMessage({
+      channel: channelId,
+      text: "aight, i'm out. ping me in another channel if u need me",
+    });
+  } catch (error) {
+    logger.warn({ error, channelId }, 'Failed to send leave acknowledgment');
+  }
+
+  try {
+    await client.conversations.leave({ channel: channelId });
+    logger.info({ channelId, userId }, 'Left channel via /gork leave');
+  } catch (error) {
+    logger.error({ error, channelId }, 'Failed to leave channel');
+    await respond({
+      text: "couldn't leave the channel — i might not be in it or something went wrong.",
+      response_type: 'ephemeral',
+    });
+  }
+}

--- a/server/slack/commands/leave.ts
+++ b/server/slack/commands/leave.ts
@@ -3,7 +3,6 @@ import type {
   SlackCommandMiddlewareArgs,
 } from '@slack/bolt';
 import { leaveChannelBlocklist } from '~/config';
-import { env } from '~/env';
 import logger from '~/lib/logger';
 
 export const name = 'leave';
@@ -16,7 +15,6 @@ export async function execute(
   await ack();
 
   const channelId = body.channel_id;
-  const userId = body.user_id;
 
   const blocked = leaveChannelBlocklist.find((c) => c.id === channelId);
   if (blocked) {
@@ -27,17 +25,14 @@ export async function execute(
     return;
   }
 
-  if (env.LOGS_CHANNEL) {
-    await client.chat.postMessage({
-      channel: env.LOGS_CHANNEL,
-      text: `<@${userId}> asked the bot to leave <#${channelId}> via /gork leave`,
-    }).catch((error) => logger.error({ error, channelId }, 'Failed to send leave-channel log'));
-  }
-
-  await client.chat.postMessage({
-    channel: channelId,
-    text: "aight, i'm out. ping me in another channel if u need me",
-  }).catch((error) => logger.warn({ error, channelId }, 'Failed to send leave acknowledgment'));
+  await client.chat
+    .postMessage({
+      channel: channelId,
+      text: "aight, i'm out. ping me in another channel if u need me",
+    })
+    .catch((error) =>
+      logger.warn({ error, channelId }, 'Failed to send leave acknowledgment')
+    );
 
   await client.conversations.leave({ channel: channelId }).catch((error) => {
     logger.error({ error, channelId }, 'Failed to leave channel');
@@ -46,6 +41,4 @@ export async function execute(
       response_type: 'ephemeral',
     });
   });
-
-  logger.info({ channelId, userId }, 'Left channel via /gork leave');
 }

--- a/server/slack/commands/leave.ts
+++ b/server/slack/commands/leave.ts
@@ -8,8 +8,6 @@ import logger from '~/lib/logger';
 
 export const name = 'leave';
 
-const SLACK_USER_ID_REGEX = /^[UW][A-Z0-9]+$/;
-
 export async function execute(
   context: SlackCommandMiddlewareArgs & AllMiddlewareArgs
 ) {
@@ -29,39 +27,25 @@ export async function execute(
     return;
   }
 
-  const safeUserId =
-    userId && SLACK_USER_ID_REGEX.test(userId) ? userId : undefined;
-
   if (env.LOGS_CHANNEL) {
-    try {
-      await client.chat.postMessage({
-        channel: env.LOGS_CHANNEL,
-        text: safeUserId
-          ? `<@${safeUserId}> asked the bot to leave <#${channelId}> via /gork leave`
-          : `The bot was asked to leave <#${channelId}> via /gork leave`,
-      });
-    } catch (error) {
-      logger.error({ error, channelId, userId }, 'Failed to send leave-channel log');
-    }
-  }
-
-  try {
     await client.chat.postMessage({
-      channel: channelId,
-      text: "aight, i'm out. ping me in another channel if u need me",
-    });
-  } catch (error) {
-    logger.warn({ error, channelId }, 'Failed to send leave acknowledgment');
+      channel: env.LOGS_CHANNEL,
+      text: `<@${userId}> asked the bot to leave <#${channelId}> via /gork leave`,
+    }).catch((error) => logger.error({ error, channelId }, 'Failed to send leave-channel log'));
   }
 
-  try {
-    await client.conversations.leave({ channel: channelId });
-    logger.info({ channelId, userId }, 'Left channel via /gork leave');
-  } catch (error) {
+  await client.chat.postMessage({
+    channel: channelId,
+    text: "aight, i'm out. ping me in another channel if u need me",
+  }).catch((error) => logger.warn({ error, channelId }, 'Failed to send leave acknowledgment'));
+
+  await client.conversations.leave({ channel: channelId }).catch((error) => {
     logger.error({ error, channelId }, 'Failed to leave channel');
-    await respond({
-      text: "couldn't leave the channel — i might not be in it or something went wrong.",
+    return respond({
+      text: "couldn't leave the channel — something went wrong.",
       response_type: 'ephemeral',
     });
-  }
+  });
+
+  logger.info({ channelId, userId }, 'Left channel via /gork leave');
 }

--- a/server/slack/commands/stop.ts
+++ b/server/slack/commands/stop.ts
@@ -1,0 +1,43 @@
+import type {
+  AllMiddlewareArgs,
+  SlackCommandMiddlewareArgs,
+} from '@slack/bolt';
+import { setSilenced } from '~/lib/kv';
+import logger from '~/lib/logger';
+
+export const name = 'stop';
+
+export async function execute(
+  context: SlackCommandMiddlewareArgs & AllMiddlewareArgs
+) {
+  const { ack, body, client, respond } = context;
+
+  await ack();
+
+  const channelId = body.channel_id;
+  const threadTs = body.thread_ts as string | undefined;
+  const userId = body.user_id;
+
+  const ctxId = threadTs ? `${channelId}:${threadTs}` : channelId;
+
+  await setSilenced(ctxId);
+
+  logger.info({ ctxId, userId }, 'Thread/channel silenced via stop command');
+
+  const scope = threadTs ? 'this thread' : 'this channel';
+
+  await respond({
+    text: `gork has been silenced in ${scope}. Use \`/gork stop\` again or ping gork directly to un-silence.`,
+    response_type: 'ephemeral',
+  });
+
+  try {
+    await client.chat.postMessage({
+      channel: channelId,
+      thread_ts: threadTs,
+      text: "aight, i'll shut up now. ping me if u wanna talk",
+    });
+  } catch (error) {
+    logger.warn({ error, ctxId }, 'Failed to send stop acknowledgment message');
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `/gork stop` subcommand that any user can invoke to immediately silence gork in the current thread or channel
- Uses the existing `setSilenced` Redis mechanism (same as the `stopTalking` AI tool) so the silence persists and is respected by the message handler
- Gork sends a brief in-character acknowledgment after being silenced
- Un-silencing still works the same way: directly ping gork (`@gork`) to resume

## Motivation

Previously, silencing gork required gork itself to decide to invoke the `stopTalking` AI tool — which it didn't always do promptly, especially while messages were queued. This gives users a direct, reliable way to stop gork without depending on AI judgment.

## Test plan

- [ ] Run `/gork stop` inside a thread — gork should stop responding to that thread and send a farewell message
- [ ] Run `/gork stop` in a channel (not a thread) — gork should stop responding in the entire channel
- [ ] Ping `@gork` after silencing — gork should un-silence and respond again
- [ ] Verify the ephemeral confirmation message appears only to the invoking user

https://claude.ai/code/session_018eqd41qvX7bSq3EaPGbUBy

---
_Generated by [Claude Code](https://claude.ai/code/session_018eqd41qvX7bSq3EaPGbUBy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/gork-stop` command to silence the bot in channels or threads.
  * Added `/gork-leave` command to remove the bot from channels, with protection for restricted channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->