### PR TITLE
feat(queue): clear pending queue items when gork is silenced

### DIFF
--- a/server/lib/ai/tools/stop-talking.ts
+++ b/server/lib/ai/tools/stop-talking.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import { setSilenced } from '~/lib/kv';
 import logger from '~/lib/logger';
+import { clearQueue } from '~/lib/queue';
 import type { SlackMessageContext } from '~/types';
 
 export const stopTalking = ({ context }: { context: SlackMessageContext }) =>
@@ -22,7 +23,11 @@ export const stopTalking = ({ context }: { context: SlackMessageContext }) =>
 
       const ctxId = `${channel}:${threadTs}`;
       await setSilenced(ctxId);
-      logger.info({ ctxId }, 'Thread silenced via stopTalking tool');
+      clearQueue(ctxId);
+      logger.info(
+        { ctxId },
+        'Thread silenced and queue cleared via stopTalking tool'
+      );
 
       return {
         success: true,

--- a/server/lib/queue.ts
+++ b/server/lib/queue.ts
@@ -11,3 +11,7 @@ export function getQueue(ctxId: string) {
   }
   return queue;
 }
+
+export function clearQueue(ctxId: string) {
+  queues.get(ctxId)?.clear();
+}

--- a/server/slack/events/message-create/index.ts
+++ b/server/slack/events/message-create/index.ts
@@ -11,7 +11,7 @@ import {
 } from '~/lib/kv';
 import logger from '~/lib/logger';
 import { saveChatMemory } from '~/lib/memory';
-import { getQueue } from '~/lib/queue';
+import { clearQueue, getQueue } from '~/lib/queue';
 import { isUserBanned } from '~/lib/reports';
 import type { SlackMessageContext } from '~/types';
 import { buildChatContext } from '~/utils/context';
@@ -164,7 +164,8 @@ async function handleMessage(args: MessageEventArgs) {
   // biome-ignore lint/performance/useTopLevelRegex: one-off pattern
   if (/^!stop\b/i.test(text)) {
     await setSilenced(ctxId);
-    logger.info({ ctxId }, 'Thread silenced via !stop message');
+    clearQueue(ctxId);
+    logger.info({ ctxId }, 'Thread silenced and queue cleared via !stop');
     await messageContext.client.chat.postMessage({
       channel: messageContext.event.channel,
       thread_ts: (messageContext.event as { thread_ts?: string }).thread_ts,


### PR DESCRIPTION
## Summary

- Adds `clearQueue(ctxId)` to `queue.ts` that drops all pending (not yet running) items from a context's PQueue
- Calls it on `!stop` message — queued responses are dropped immediately alongside the silence flag being set
- Calls it in the `stopTalking` AI tool for the same reason

## Test plan

- [ ] Send several messages in quick succession then type `!stop` — gork should not send any queued responses after the farewell
- [ ] Ask gork to stop talking via chat — it should silence itself and drop pending queue items

https://claude.ai/code/session_018eqd41qvX7bSq3EaPGbUBy

---
_Generated by [Claude Code](https://claude.ai/code/session_018eqd41qvX7bSq3EaPGbUBy)_