### PR TITLE
fix(messages): handle !stop before enqueueing so queue clears immediately

### DIFF
--- a/server/slack/events/message-create/index.ts
+++ b/server/slack/events/message-create/index.ts
@@ -159,21 +159,6 @@ async function handleMessage(args: MessageEventArgs) {
     return;
   }
 
-  const text = (messageContext.event as { text?: string }).text ?? '';
-
-  // biome-ignore lint/performance/useTopLevelRegex: one-off pattern
-  if (/^!stop\b/i.test(text)) {
-    await setSilenced(ctxId);
-    clearQueue(ctxId);
-    logger.info({ ctxId }, 'Thread silenced and queue cleared via !stop');
-    await messageContext.client.chat.postMessage({
-      channel: messageContext.event.channel,
-      thread_ts: (messageContext.event as { thread_ts?: string }).thread_ts,
-      text: "aight, i'll shut up now. ping me if u wanna talk",
-    });
-    return;
-  }
-
   const trigger = await getTrigger(
     messageContext,
     keywords,
@@ -333,6 +318,21 @@ export async function execute(args: MessageEventArgs) {
 
   const ctxId = getContextId(messageContext);
   if (!(await canReply(ctxId))) {
+    return;
+  }
+
+  const text = (messageContext.event as { text?: string }).text ?? '';
+
+  // biome-ignore lint/performance/useTopLevelRegex: one-off pattern
+  if (/^!stop\b/i.test(text)) {
+    await setSilenced(ctxId);
+    clearQueue(ctxId);
+    logger.info({ ctxId }, 'Thread silenced and queue cleared via !stop');
+    await messageContext.client.chat.postMessage({
+      channel: messageContext.event.channel,
+      thread_ts: (messageContext.event as { thread_ts?: string }).thread_ts,
+      text: "aight, i'll shut up now. ping me if u wanna talk",
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary

- Moves the `!stop` check from inside `handleMessage` (which runs inside the queue) to `execute()` (which runs before enqueuing)
- This means when `!stop` arrives, the queue is cleared immediately — queued responses can no longer slip through before the stop is acknowledged

## Why this matters

Previously: `!stop` sat behind already-queued messages and only ran after they fired.  
Now: `!stop` bypasses the queue entirely, clears it, then sends the farewell.

https://claude.ai/code/session_018eqd41qvX7bSq3EaPGbUBy

---
_Generated by [Claude Code](https://claude.ai/code/session_018eqd41qvX7bSq3EaPGbUBy)_