### PR TITLE
fix: prevent gork from pinging user groups and broadcast mentions

### DIFF
--- a/.cspell.jsonc
+++ b/.cspell.jsonc
@@ -51,6 +51,8 @@
     "Usergroup",
     "usergroup",
     "usergroups",
+    "subteam",
+    "subteams",
     "behaviour",
     "docstrings",
     "unconfigured"

--- a/server/lib/ai/prompts/core.ts
+++ b/server/lib/ai/prompts/core.ts
@@ -8,6 +8,7 @@ Details:
 
 Slack Basics:
 - Mention people with <@USER_ID> (IDs are available via getUserInfo).
+- NEVER use <!subteam^...>, <!here>, <!channel>, or <!everyone> syntax. You cannot ping user groups, subteams, or broadcast to a channel.
 - Messages appear as \`display-name (user-id): text\` in the logs you see.
 - Slack Markdown is different to standard Markdown. Make sure to use syntax that would work for Slack's Markdown implementation.
 - Keep replies short and natural. If you won't respond, use the "skip" tool.

--- a/server/lib/ai/tools/reply.ts
+++ b/server/lib/ai/tools/reply.ts
@@ -108,7 +108,13 @@ export const reply = ({ context }: { context: SlackMessageContext }) =>
             ? resolveThreadTs(target, currentThread ?? messageTs)
             : undefined;
 
-        for (const text of content) {
+        for (const raw of content) {
+          // Strip Slack broadcast/group mentions so the bot can't ping user groups, @here, @channel, or @everyone.
+          const text = raw
+            .replace(/<!subteam\^[^>]+>/g, '')
+            .replace(/<!here\|?[^>]*>/g, '')
+            .replace(/<!channel\|?[^>]*>/g, '')
+            .replace(/<!everyone>/g, '');
           await context.client.chat.postMessage({
             channel: channelId,
             text,


### PR DESCRIPTION
## Summary

- Strip `<!subteam^...>`, `<!here>`, `<!channel>`, and `<!everyone>` from outgoing message text in `reply.ts` before posting to Slack
- Add explicit instructions to the system prompt so the model doesn't generate these mentions in the first place

## Test plan

- [ ] Trigger gork in a channel with a user group present and confirm it doesn't ping the group
- [ ] Confirm `@here`/`@channel`/`@everyone` are also stripped from replies
- [ ] Confirm normal `<@USER_ID>` mentions still work correctly

https://claude.ai/code/session_0188bDEjiBTB6gh13d6yG5FQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0188bDEjiBTB6gh13d6yG5FQ)_