### PR TITLE
refactor: remove inline user cache, use getSlackUserName on-demand

### DIFF
--- a/server/slack/conversations.ts
+++ b/server/slack/conversations.ts
@@ -2,6 +2,7 @@ import type { ConversationsHistoryResponse, WebClient } from '@slack/web-api';
 import type { ModelMessage, UserContent } from 'ai';
 import logger from '~/lib/logger';
 import { processSlackFiles, type SlackFile } from '~/utils/images';
+import { getSlackUserName } from '~/utils/users';
 
 interface ConversationOptions {
   botUserId?: string;
@@ -62,31 +63,6 @@ export async function getConversationMessages({
         })
       : messages;
 
-    const userIds = new Set<string>();
-    for (const message of filteredMessages) {
-      if (message.user) {
-        userIds.add(message.user);
-      }
-    }
-
-    const userNameCache = new Map<string, string>();
-    await Promise.all(
-      Array.from(userIds).map(async (userId) => {
-        try {
-          const info = await client.users.info({ user: userId });
-          const name =
-            info.user?.profile?.display_name ||
-            info.user?.real_name ||
-            info.user?.name ||
-            userId;
-          userNameCache.set(userId, name);
-        } catch (error) {
-          logger.warn({ error, userId }, 'Failed to fetch Slack user info');
-          userNameCache.set(userId, userId);
-        }
-      })
-    );
-
     const mentionRegex = botUserId ? new RegExp(`<@${botUserId}>`, 'gi') : null;
 
     const sortedMessages = filteredMessages
@@ -97,37 +73,36 @@ export async function getConversationMessages({
         return aTs - bTs;
       });
 
-    const modelMessages: ModelMessage[] = await Promise.all(
-      sortedMessages.map(async (message): Promise<ModelMessage> => {
-        const isBot = message.user === botUserId || Boolean(message.bot_id);
-        const original = message.text ?? '';
-        const cleaned = mentionRegex
-          ? original.replace(mentionRegex, '').trim()
-          : original.trim();
+    const modelMessages: ModelMessage[] = [];
+    for (const message of sortedMessages) {
+      const isBot = message.user === botUserId || Boolean(message.bot_id);
+      const original = message.text ?? '';
+      const cleaned = mentionRegex
+        ? original.replace(mentionRegex, '').trim()
+        : original.trim();
 
-        const textContent = cleaned.length > 0 ? cleaned : original;
+      const textContent = cleaned.length > 0 ? cleaned : original;
 
-        const author = message.user
-          ? (userNameCache.get(message.user) ?? message.user)
-          : (message.bot_id ?? 'unknown');
+      const author = message.user
+        ? await getSlackUserName(client, message.user)
+        : (message.bot_id ?? 'unknown');
 
-        const formattedText = `${author} (${message.user}): ${textContent}`;
+      const formattedText = `${author} (${message.user}): ${textContent}`;
 
-        if (isBot) {
-          return { role: 'assistant', content: formattedText };
-        }
-
+      if (isBot) {
+        modelMessages.push({ role: 'assistant', content: formattedText });
+      } else {
         const images = await processSlackFiles(
           message.files as SlackFile[] | undefined
         );
-        return {
+        modelMessages.push({
           role: 'user',
           content: (images.length
             ? [{ type: 'text', text: formattedText }, ...images]
             : formattedText) as UserContent,
-        };
-      })
-    );
+        });
+      }
+    }
 
     return modelMessages;
   } catch (error) {

--- a/server/slack/events/message-create/utils/message.ts
+++ b/server/slack/events/message-create/utils/message.ts
@@ -2,6 +2,7 @@ import type { AllMiddlewareArgs, SlackEventMiddlewareArgs } from '@slack/bolt';
 import { loadingMessages } from '~/config';
 import logger from '~/lib/logger';
 import type { SlackMessageContext } from '~/types';
+import { getSlackUserName } from '~/utils/users';
 
 export function setThreadStatus({
   ctx,
@@ -70,18 +71,7 @@ export async function getAuthorName(ctx: SlackMessageContext): Promise<string> {
   if (!userId) {
     return 'unknown';
   }
-  try {
-    const info = await ctx.client.users.info({ user: userId });
-    return (
-      info.user?.profile?.display_name ||
-      info.user?.real_name ||
-      info.user?.name ||
-      userId
-    );
-  } catch (error) {
-    logger.warn({ error, userId }, 'Failed to fetch user info for logging');
-    return userId;
-  }
+  return getSlackUserName(ctx.client, userId);
 }
 
 export function getContextId(ctx: SlackMessageContext): string {

--- a/server/utils/triggers.ts
+++ b/server/utils/triggers.ts
@@ -1,6 +1,6 @@
 import type { SlackMessageContext } from '~/types';
 import { getGroupMentions } from '~/utils/blocks';
-import { primeSlackUserName } from '~/utils/users';
+import { getSlackUserName } from '~/utils/users';
 
 export type TriggerType = 'ping' | 'keyword' | 'dm' | null;
 
@@ -34,17 +34,8 @@ export async function getTrigger(
   const content = event.text.trim();
 
   if (botId && content.includes(`<@${botId}>`)) {
-    try {
-      const info = await client.users.info({ user: botId });
-      const displayName =
-        info.user?.profile?.display_name || info.user?.name || null;
-      if (displayName) {
-        primeSlackUserName(botId, displayName);
-      }
-      return { type: 'ping', info: displayName ?? botId };
-    } catch {
-      return { type: 'ping', info: botId };
-    }
+    const displayName = await getSlackUserName(client, botId);
+    return { type: 'ping', info: displayName };
   }
 
   if (botId) {

--- a/server/utils/users.ts
+++ b/server/utils/users.ts
@@ -36,13 +36,6 @@ export async function getSlackUserName(
   }
 }
 
-export function primeSlackUserName(userId: string, name: string) {
-  if (!userId) {
-    return;
-  }
-  userNameCache.set(userId, name);
-}
-
 export function normalizeSlackUserId(raw: string): string {
   const match = USER_MENTION_RE.exec(raw);
   return match?.[1] ?? raw.trim();


### PR DESCRIPTION
## Summary

Removes the inline bulk user pre-fetch in `conversations.ts` that was causing Slack rate limit bursts in large channels. Replaces with on-demand `getSlackUserName` calls via a serial loop.

## Changes

- **`conversations.ts`**: Removed inline `users.info` bulk pre-fetch (40 parallel calls). Now calls `getSlackUserName` on-demand per message in a serial loop — at most 1 concurrent API call vs 40.
- **`triggers.ts`**: Replaced inline `client.users.info` with `getSlackUserName` (was bypassing the global cache).
- **`message.ts`**: Replaced inline `client.users.info` in `getAuthorName` with `getSlackUserName`.
- **`users.ts`**: Removed dead `primeSlackUserName` (no callers after above changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved consistency of Slack username resolution throughout the application
  * Streamlined how user display names are retrieved and displayed across message processing and bot mentions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techwithanirudh/gork-slack/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->