### PR TITLE
Lower max strike ban threshold from 15 to 3

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -46,7 +46,7 @@ export const channelMode = {
 };
 
 export const moderation = {
-  banThreshold: 15,
+  banThreshold: 3,
   // Number of recent messages attached to automated report context.
   contextMessages: 3,
   reports: {


### PR DESCRIPTION
This PR lowers the \$\{\}\banThreshold\$\{\}\ from 15 to 3, so users are banned after 3 strikes instead of 15.\n\nAll dynamic references to \$\{\}\banThreshold\$\{\}\ (e.g. strike counters, notifications, moderation info) will automatically reflect the new value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated moderation settings so automatic bans occur after 3 strikes instead of 15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->